### PR TITLE
Add GUCT Power and Uniform search variants

### DIFF
--- a/dev/evaluate_agile.py
+++ b/dev/evaluate_agile.py
@@ -29,6 +29,8 @@ SEARCHES = {
     "gbfs": search.gbfs_search,
     "guct-normal": search.guct_normal_search,
     "guct-normal2": search.guct_normal2_search,
+    "guct-power": search.guct_power_search,
+    "guct-uniform": search.guct_uniform_search,
 }
 
 MAX_GROUND_TIME = 60  # seconds

--- a/dev/evaluate_agile.py
+++ b/dev/evaluate_agile.py
@@ -20,9 +20,9 @@ from pyperplan import heuristics, planner, search
 
 HEURISTICS = {
     "h-ff": heuristics.hFFHeuristic,
-    "h-add": heuristics.hAddHeuristic,
-    "h-max": heuristics.hMaxHeuristic,
-    "h-gc": heuristics.GoalCountHeuristic,
+    # "h-add": heuristics.hAddHeuristic,
+    # "h-max": heuristics.hMaxHeuristic,
+    # "h-gc": heuristics.GoalCountHeuristic,
 }
 
 SEARCHES = {
@@ -153,6 +153,7 @@ def plot_results(results):
     plt.legend()
     plt.tight_layout()
     plt.savefig("evaluation_plot.png")
+    plt.close()
 
 
 if __name__ == "__main__":

--- a/dev/evaluate_agile.py
+++ b/dev/evaluate_agile.py
@@ -142,6 +142,8 @@ def evaluate():
 def plot_results(results):
     limits = range(1, MAX_EXPANSIONS)
     for name, runs in results.items():
+        if "h-ff" not in name:
+            continue
         solved_counts = []
         for lim in limits:
             solved_counts.append(sum(1 for r in runs if r <= lim))

--- a/pyperplan/search/__init__.py
+++ b/pyperplan/search/__init__.py
@@ -19,7 +19,12 @@ from .a_star import astar_search, greedy_best_first_search, weighted_astar_searc
 from .breadth_first_search import breadth_first_search
 from .enforced_hillclimbing_search import enforced_hillclimbing_search
 from .gbfs import gbfs_search
-from .guct import guct_normal2_search, guct_normal_search
+from .guct import (
+    guct_normal2_search,
+    guct_normal_search,
+    guct_power_search,
+    guct_uniform_search,
+)
 from .iterative_deepening_search import iterative_deepening_search
 from .sat import sat_solve
 from .searchspace import make_child_node, make_root_node

--- a/pyperplan/search/guct.py
+++ b/pyperplan/search/guct.py
@@ -19,17 +19,70 @@
 import heapq
 import logging
 import math
-import random
+from dataclasses import dataclass
 
 from . import searchspace
 
 
-def _ucb_score(mean, visits, parent_visits, c):
-    if visits == 0:
+@dataclass
+class _Stats:
+    visits: int
+    mean: float
+    m2: float
+    min_val: float
+    max_val: float
+
+
+def _make_stats(value: float) -> _Stats:
+    return _Stats(1, value, 0.0, value, value)
+
+
+def _update_stats(stats: _Stats, value: float) -> None:
+    stats.visits += 1
+    delta = value - stats.mean
+    stats.mean += delta / stats.visits
+    stats.m2 += delta * (value - stats.mean)
+    stats.min_val = min(stats.min_val, value)
+    stats.max_val = max(stats.max_val, value)
+
+
+def _variance(stats: _Stats) -> float:
+    return 0.0 if stats.visits <= 1 else stats.m2 / (stats.visits - 1)
+
+
+def _stddev(stats: _Stats) -> float:
+    return math.sqrt(_variance(stats))
+
+
+def _score_ucb_normal(stats: _Stats, total: int) -> float:
+    n = stats.visits
+    if n == 0:
         return float("-inf")
-    return mean - c * math.sqrt(math.log(parent_visits) / visits)
+    return stats.mean - math.sqrt(2 * math.log(total) / n) - (
+        3 * _variance(stats) * math.log(total) / n
+    )
 
 
+def _score_ucb_normal2(stats: _Stats, total: int) -> float:
+    n = stats.visits
+    if n == 0:
+        return float("-inf")
+    return stats.mean - _stddev(stats) * math.sqrt(2 * math.log(total) / n)
+
+
+def _score_lcb_uniform(stats: _Stats, total: int) -> float:
+    n = stats.visits
+    return (stats.max_val + stats.min_val) / 2 - (
+        stats.max_val - stats.min_val
+    ) * math.sqrt(6 * math.log(total) / n)
+
+
+def _score_lcb_power(stats: _Stats, total: int) -> float:
+    n = stats.visits
+    a_hat = 1.0
+    return (stats.max_val * a_hat) / (a_hat + 1) + stats.max_val * math.sqrt(
+        6 * math.log(total) / n
+    )
 
 
 def _guct_search(task, heuristic, score_fun, max_expansions=None):
@@ -39,7 +92,7 @@ def _guct_search(task, heuristic, score_fun, max_expansions=None):
 
     root = searchspace.make_root_node(task.initial_state)
     init_h = heuristic(root)
-    node_info[root] = 1
+    node_info[root] = _make_stats(init_h)
     heapq.heappush(open_list, (init_h, tie, root))
     tie += 1
     logging.info("Initial h value: %f" % init_h)
@@ -49,8 +102,12 @@ def _guct_search(task, heuristic, score_fun, max_expansions=None):
         if max_expansions is not None and expansions >= max_expansions:
             break
         score, _, node = heapq.heappop(open_list)
-        parent_visits = node_info.get(node, 1)
-        node_info[node] = parent_visits + 1
+        parent_stats = node_info.get(node)
+        if parent_stats is None:
+            parent_stats = _make_stats(heuristic(node))
+            node_info[node] = parent_stats
+        parent_stats.visits += 1
+        parent_visits = parent_stats.visits
         expansions += 1
 
         if task.goal_reached(node.state):
@@ -61,9 +118,13 @@ def _guct_search(task, heuristic, score_fun, max_expansions=None):
         for op, succ_state in task.get_successor_states(node.state):
             succ = searchspace.make_child_node(node, op, succ_state)
             h_val = heuristic(succ)
-            visits = node_info.get(succ, 0) + 1
-            node_info[succ] = visits
-            ucb = score_fun(h_val, visits, parent_visits + 1)
+            stats = node_info.get(succ)
+            if stats is None:
+                stats = _make_stats(h_val)
+                node_info[succ] = stats
+            else:
+                _update_stats(stats, h_val)
+            ucb = score_fun(stats, parent_visits + 1)
             heapq.heappush(open_list, (ucb, tie, succ))
             tie += 1
 
@@ -75,42 +136,22 @@ def _guct_search(task, heuristic, score_fun, max_expansions=None):
 def guct_normal_search(task, heuristic, max_expansions=None):
     """GUCT search variant using UCB1-Normal."""
 
-    return _guct_search(
-        task,
-        heuristic,
-        lambda m, v, pv: _ucb_score(m, v, pv, 1.0),
-        max_expansions=max_expansions,
-    )
+    return _guct_search(task, heuristic, _score_ucb_normal, max_expansions)
 
 
 def guct_normal2_search(task, heuristic, max_expansions=None):
     """GUCT search variant using UCB1-Normal2."""
 
-    return _guct_search(
-        task,
-        heuristic,
-        lambda m, v, pv: _ucb_score(m, v, pv, 2.0),
-        max_expansions=max_expansions,
-    )
+    return _guct_search(task, heuristic, _score_ucb_normal2, max_expansions)
 
 
 def guct_uniform_search(task, heuristic, max_expansions=None):
     """GUCT search variant using LCB1-Uniform."""
 
-    return _guct_search(
-        task,
-        heuristic,
-        lambda m, v, pv: _ucb_score(m, v, pv, 1.5),
-        max_expansions=max_expansions,
-    )
+    return _guct_search(task, heuristic, _score_lcb_uniform, max_expansions)
 
 
 def guct_power_search(task, heuristic, max_expansions=None):
     """GUCT search variant using LCB1-Power."""
 
-    return _guct_search(
-        task,
-        heuristic,
-        lambda m, v, pv: _ucb_score(m, v, pv, 0.5),
-        max_expansions=max_expansions,
-    )
+    return _guct_search(task, heuristic, _score_lcb_power, max_expansions)

--- a/pyperplan/search/guct.py
+++ b/pyperplan/search/guct.py
@@ -31,19 +31,24 @@ class _Stats:
     m2: float
     min_val: float
     max_val: float
+    log_sum:  float
 
 
 def _make_stats(value: float) -> _Stats:
-    return _Stats(1, value, 0.0, value, value)
+    v = max(value, 1e-9)                       # protect log(0)
+    return _Stats(1, value, 0.0, value, value, math.log(v))
 
 
 def _update_stats(stats: _Stats, value: float) -> None:
+    v = max(value, 1e-9)
     stats.visits += 1
+
     delta = value - stats.mean
     stats.mean += delta / stats.visits
     stats.m2 += delta * (value - stats.mean)
     stats.min_val = min(stats.min_val, value)
     stats.max_val = max(stats.max_val, value)
+    stats.log_sum += math.log(v)
 
 
 def _variance(stats: _Stats) -> float:
@@ -52,6 +57,14 @@ def _variance(stats: _Stats) -> float:
 
 def _stddev(stats: _Stats) -> float:
     return math.sqrt(_variance(stats))
+
+def _a_hat(stats: _Stats) -> float:
+    if stats.visits < 2 or stats.max_val <= 0:
+        return 1.0
+    denom = math.log(stats.max_val) - (stats.log_sum / stats.visits)
+    if denom <= 0.0:
+        return 1.0
+    return 1.0 / denom
 
 
 def _score_lcb_normal(stats: _Stats, total: int) -> float:
@@ -71,12 +84,12 @@ def _score_lcb_uniform(stats: _Stats, total: int) -> float:
     n = stats.visits
     if total == 0:
         return float("-inf")
-    return (stats.max_val - stats.min_val) / 2 - (stats.max_val - stats.min_val) * math.sqrt(6 * n * math.log(total))
+    return (stats.max_val + stats.min_val) / 2 - (stats.max_val - stats.min_val) * math.sqrt(6 * n * math.log(total))
 
 
 def _score_lcb_power(stats: _Stats, total: int) -> float:
     n = stats.visits
-    a_hat = 1.0
+    a_hat = _a_hat(stats)
     if total == 0:
         return float("-inf")
     return (stats.max_val * a_hat) / (a_hat + 1) - stats.max_val * math.sqrt(6 * n * math.log(total))

--- a/pyperplan/search/guct.py
+++ b/pyperplan/search/guct.py
@@ -30,7 +30,9 @@ def _ucb_score(mean, visits, parent_visits, c):
     return mean - c * math.sqrt(math.log(parent_visits) / visits)
 
 
-def _guct_search(task, heuristic, c=1.0, max_expansions=None):
+
+
+def _guct_search(task, heuristic, score_fun, max_expansions=None):
     open_list = []
     node_info = {}
     tie = 0
@@ -61,7 +63,7 @@ def _guct_search(task, heuristic, c=1.0, max_expansions=None):
             h_val = heuristic(succ)
             visits = node_info.get(succ, 0) + 1
             node_info[succ] = visits
-            ucb = _ucb_score(h_val, visits, parent_visits + 1, c)
+            ucb = score_fun(h_val, visits, parent_visits + 1)
             heapq.heappush(open_list, (ucb, tie, succ))
             tie += 1
 
@@ -73,10 +75,42 @@ def _guct_search(task, heuristic, c=1.0, max_expansions=None):
 def guct_normal_search(task, heuristic, max_expansions=None):
     """GUCT search variant using UCB1-Normal."""
 
-    return _guct_search(task, heuristic, c=1.0, max_expansions=max_expansions)
+    return _guct_search(
+        task,
+        heuristic,
+        lambda m, v, pv: _ucb_score(m, v, pv, 1.0),
+        max_expansions=max_expansions,
+    )
 
 
 def guct_normal2_search(task, heuristic, max_expansions=None):
     """GUCT search variant using UCB1-Normal2."""
 
-    return _guct_search(task, heuristic, c=2.0, max_expansions=max_expansions)
+    return _guct_search(
+        task,
+        heuristic,
+        lambda m, v, pv: _ucb_score(m, v, pv, 2.0),
+        max_expansions=max_expansions,
+    )
+
+
+def guct_uniform_search(task, heuristic, max_expansions=None):
+    """GUCT search variant using LCB1-Uniform."""
+
+    return _guct_search(
+        task,
+        heuristic,
+        lambda m, v, pv: _ucb_score(m, v, pv, 1.5),
+        max_expansions=max_expansions,
+    )
+
+
+def guct_power_search(task, heuristic, max_expansions=None):
+    """GUCT search variant using LCB1-Power."""
+
+    return _guct_search(
+        task,
+        heuristic,
+        lambda m, v, pv: _ucb_score(m, v, pv, 0.5),
+        max_expansions=max_expansions,
+    )

--- a/pyperplan/search/guct.py
+++ b/pyperplan/search/guct.py
@@ -54,35 +54,32 @@ def _stddev(stats: _Stats) -> float:
     return math.sqrt(_variance(stats))
 
 
-def _score_ucb_normal(stats: _Stats, total: int) -> float:
+def _score_lcb_normal(stats: _Stats, total: int) -> float:
     n = stats.visits
     if n == 0:
         return float("-inf")
-    return stats.mean - math.sqrt(2 * math.log(total) / n) - (
-        3 * _variance(stats) * math.log(total) / n
-    )
+    return stats.mean - _stddev(stats) * math.sqrt((16 * math.log(total)) / n)
 
 
-def _score_ucb_normal2(stats: _Stats, total: int) -> float:
-    n = stats.visits
-    if n == 0:
+def _score_lcb_normal2(stats: _Stats, total: int) -> float:
+    if total == 0:
         return float("-inf")
-    return stats.mean - _stddev(stats) * math.sqrt(2 * math.log(total) / n)
+    return stats.mean - _stddev(stats) * math.sqrt(2 * math.log(total))
 
 
 def _score_lcb_uniform(stats: _Stats, total: int) -> float:
     n = stats.visits
-    return (stats.max_val + stats.min_val) / 2 - (
-        stats.max_val - stats.min_val
-    ) * math.sqrt(6 * math.log(total) / n)
+    if total == 0:
+        return float("-inf")
+    return (stats.max_val - stats.min_val) / 2 - (stats.max_val - stats.min_val) * math.sqrt(6 * n * math.log(total))
 
 
 def _score_lcb_power(stats: _Stats, total: int) -> float:
     n = stats.visits
     a_hat = 1.0
-    return (stats.max_val * a_hat) / (a_hat + 1) + stats.max_val * math.sqrt(
-        6 * math.log(total) / n
-    )
+    if total == 0:
+        return float("-inf")
+    return (stats.max_val * a_hat) / (a_hat + 1) - stats.max_val * math.sqrt(6 * n * math.log(total))
 
 
 def _guct_search(task, heuristic, score_fun, max_expansions=None):
@@ -136,13 +133,13 @@ def _guct_search(task, heuristic, score_fun, max_expansions=None):
 def guct_normal_search(task, heuristic, max_expansions=None):
     """GUCT search variant using UCB1-Normal."""
 
-    return _guct_search(task, heuristic, _score_ucb_normal, max_expansions)
+    return _guct_search(task, heuristic, _score_lcb_normal, max_expansions)
 
 
 def guct_normal2_search(task, heuristic, max_expansions=None):
     """GUCT search variant using UCB1-Normal2."""
 
-    return _guct_search(task, heuristic, _score_ucb_normal2, max_expansions)
+    return _guct_search(task, heuristic, _score_lcb_normal2, max_expansions)
 
 
 def guct_uniform_search(task, heuristic, max_expansions=None):

--- a/pyperplan/tests/test_guct_search.py
+++ b/pyperplan/tests/test_guct_search.py
@@ -1,4 +1,9 @@
-from pyperplan.search import guct_normal2_search, guct_normal_search
+from pyperplan.search import (
+    guct_normal2_search,
+    guct_normal_search,
+    guct_power_search,
+    guct_uniform_search,
+)
 from pyperplan.tests import dummy_task
 
 
@@ -15,6 +20,12 @@ def test_guct_at_goal():
     plan2, expansions2 = _run(guct_normal2_search, task)
     assert plan2 == []
     assert expansions2 >= 1
+    plan3, expansions3 = _run(guct_power_search, task)
+    assert plan3 == []
+    assert expansions3 >= 1
+    plan4, expansions4 = _run(guct_uniform_search, task)
+    assert plan4 == []
+    assert expansions4 >= 1
 
 
 def test_guct_three_step():
@@ -25,6 +36,12 @@ def test_guct_three_step():
     plan2, exp2 = _run(guct_normal2_search, task)
     assert plan2 is not None and len(plan2) == 3
     assert exp2 >= len(plan2)
+    plan3, exp3 = _run(guct_power_search, task)
+    assert plan3 is not None and len(plan3) == 3
+    assert exp3 >= len(plan3)
+    plan4, exp4 = _run(guct_uniform_search, task)
+    assert plan4 is not None and len(plan4) == 3
+    assert exp4 >= len(plan4)
 
 
 def test_guct_no_solution():
@@ -35,3 +52,9 @@ def test_guct_no_solution():
     plan2, exp2 = _run(guct_normal2_search, task)
     assert plan2 is None
     assert exp2 == 50
+    plan3, exp3 = _run(guct_power_search, task)
+    assert plan3 is None
+    assert exp3 == 50
+    plan4, exp4 = _run(guct_uniform_search, task)
+    assert plan4 is None
+    assert exp4 == 50


### PR DESCRIPTION
## Summary
- implement `guct_power_search` and `guct_uniform_search`
- export new algorithms in `search.__init__`
- allow comparing the variants in `dev/evaluate_agile.py`
- extend tests to cover the new algorithms

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684098d06af48326bf263bb6c6ba52fb